### PR TITLE
Adds option to allow loading paymentpage in an iframe

### DIFF
--- a/src/Umbraco.Commerce.PaymentProviders.Quickpay/Api/Models/QuickpayPaymentLinkRequest.cs
+++ b/src/Umbraco.Commerce.PaymentProviders.Quickpay/Api/Models/QuickpayPaymentLinkRequest.cs
@@ -51,5 +51,11 @@ namespace Umbraco.Commerce.PaymentProviders.Quickpay.Api.Models
         /// </summary>
         [JsonProperty("auto_capture")]
         public bool? AutoCapture { get; set; }
+
+        /// <summary>
+        /// Allow opening in iframe. Default is false.
+        /// </summary>
+        [JsonProperty("framed")]
+        public bool? Framed { get; set; }
     }
 }

--- a/src/Umbraco.Commerce.PaymentProviders.Quickpay/QuickpayCheckoutPaymentProvider.cs
+++ b/src/Umbraco.Commerce.PaymentProviders.Quickpay/QuickpayCheckoutPaymentProvider.cs
@@ -137,7 +137,9 @@ namespace Umbraco.Commerce.PaymentProviders.Quickpay
                             CallbackUrl = ctx.Urls.CallbackUrl,
                             PaymentMethods = paymentMethods?.Length > 0 ? string.Join(",", paymentMethods) : null,
                             AutoFee = ctx.Settings.AutoFee,
-                            AutoCapture = ctx.Settings.AutoCapture
+                            AutoCapture = ctx.Settings.AutoCapture,
+                            Framed = ctx.Settings.Framed
+                            
                         },
                         cancellationToken).ConfigureAwait(false);
 

--- a/src/Umbraco.Commerce.PaymentProviders.Quickpay/QuickpayCheckoutSettings.cs
+++ b/src/Umbraco.Commerce.PaymentProviders.Quickpay/QuickpayCheckoutSettings.cs
@@ -13,5 +13,10 @@ namespace Umbraco.Commerce.PaymentProviders.Quickpay
             Description = "Flag indicating whether to immediately capture the payment, or whether to just authorize the payment for later (manual) capture.",
             SortOrder = 1200)]
         public bool AutoCapture { get; set; }
+
+        [PaymentProviderSetting(Name = "Framed",
+            Description = "Flag indicating whether to allow opening payment page in iframe.",
+            SortOrder = 1300)]
+        public bool Framed { get; set; }
     }
 }


### PR DESCRIPTION
This adds an option to allow loading the paymentpage in an iframe by specifying the `framed` property on the settings object used to generate the payment link.

For more info https://quickpay.net/helpdesk/iframe/