### PR TITLE
Fix trim of order number based on order number template

### DIFF
--- a/src/Umbraco.Commerce.PaymentProviders.Quickpay/Api/QuickpayClient.cs
+++ b/src/Umbraco.Commerce.PaymentProviders.Quickpay/Api/QuickpayClient.cs
@@ -98,6 +98,10 @@ namespace Umbraco.Commerce.PaymentProviders.Quickpay.Api
             {
                 throw;
             }
+            catch (Exception ex)
+            {
+                throw;
+            }
 
             return result;
         }

--- a/src/Umbraco.Commerce.PaymentProviders.Quickpay/QuickpayCheckoutPaymentProvider.cs
+++ b/src/Umbraco.Commerce.PaymentProviders.Quickpay/QuickpayCheckoutPaymentProvider.cs
@@ -98,12 +98,12 @@ namespace Umbraco.Commerce.PaymentProviders.Quickpay
                             else if (orderNumberTemplate.EndsWith("{0}"))
                             {
                                 // Trim prefix
-                                reference = reference.Substring(prefix.Length - 1);
+                                reference = reference.Substring(prefix.Length);
                             }
                             else if (orderNumberTemplate.Contains("{0}"))
                             {
                                 // Trim prefix & suffix
-                                reference = reference.Substring(prefix.Length - 1, reference.Length - suffix.Length);
+                                reference = reference.Substring(prefix.Length, reference.Length - prefix.Length - suffix.Length);
                             }
                         }
                     }


### PR DESCRIPTION
Fix trim of order number based on order number template since QuickPay has a limit of order id between 4-20 characters.

Ends with `{0}`:

![image](https://github.com/umbraco/Umbraco.Commerce.PaymentProviders.Quickpay/assets/2919859/6397949e-36db-4612-97d6-ee9b653a957c)


Contains `{0}`:

![image](https://github.com/umbraco/Umbraco.Commerce.PaymentProviders.Quickpay/assets/2919859/c533e227-5db7-4403-bede-0de1727e4a4f)
