### PR TITLE
Report transaction fee from Quickpay payment callback

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,6 +11,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Flurl.Http" Version="[4.0.2, 4.999.999)" />
-    <PackageVersion Include="Umbraco.Commerce.Core" Version="[17.0.0, 17.999.999)" />
+    <PackageVersion Include="Umbraco.Commerce.Core" Version="[17.1.3, 17.999.999)" />
   </ItemGroup>
 </Project>

--- a/src/Umbraco.Commerce.PaymentProviders.Quickpay/QuickpayCheckoutPaymentProvider.cs
+++ b/src/Umbraco.Commerce.PaymentProviders.Quickpay/QuickpayCheckoutPaymentProvider.cs
@@ -233,6 +233,7 @@ namespace Umbraco.Commerce.PaymentProviders.Quickpay
                             AmountAuthorized = AmountFromMinorUnits(totalAmount),
                             TransactionId = GetTransactionId(payment),
                             PaymentStatus = newPaymentStatus,
+                            TransactionFee = AmountFromMinorUnits(payment.Fee ?? 0),
                         },
                     };
                 }

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "17.0.0",
+  "version": "17.0.1",
   "assemblyVersion": {
     "precision": "build"
   },


### PR DESCRIPTION
## Summary

- Populates `TransactionFee` on the `CallbackResult.TransactionInfo` in `ProcessCallbackAsync` using `payment.Fee` from the Quickpay API response
- When `auto_fee: true` is configured on the payment link, Quickpay adds its fee on top of the authorized amount — this change ensures that fee is explicitly tracked in Umbraco Commerce rather than being silently discarded

## Dependency

This PR requires a fix in `Umbraco.Commerce.Core` to be released first: https://github.com/umbraco/Umbraco.Commerce/pull/100

Without that Core fix, `AuthorizeTransactionActivity` has no fee-aware constructor and `TransactionActivityFactory` discards the `transactionFee` for `PaymentStatus.Authorized`, meaning the fee reported here would never be stored.

## Test plan

- [ ] Configure a Quickpay payment link with `auto_fee: true`
- [ ] Complete a payment and verify the transaction fee (e.g. `payment.Fee = 185` → 1.85 EUR) is recorded on the authorize activity in Umbraco Commerce
- [ ] Verify the fee survives through to capture

🤖 Generated with [Claude Code](https://claude.com/claude-code)